### PR TITLE
change upload of fastd-keys to optimize usage of ressources

### DIFF
--- a/files/lib/freifunk/mesh-vpn/fastd.conf
+++ b/files/lib/freifunk/mesh-vpn/fastd.conf
@@ -4,7 +4,6 @@ peer group "backbone" {
 }
 
 on up "
-	/lib/freifunk/mesh-vpn/upload_key
 	if [ \"$(uci get freifunk.@bandwidth[0].enabled)\" = 1 ]; then
 		tc qdisc add dev $INTERFACE root tbf rate \"$(uci get freifunk.@bandwidth[0].upstream)kbit\" latency 50ms burst 2k
 
@@ -12,5 +11,6 @@ on up "
 		tc filter add dev $INTERFACE parent ffff: u32 match u8 00 00 at 0 police rate \"$(uci get freifunk.@bandwidth[0].downstream)kbit\" burst 10k drop flowid :1
 	fi
 	echo enabled > /sys/devices/virtual/net/$INTERFACE/batman_adv/no_rebroadcast
+	/lib/freifunk/mesh-vpn/upload_key_to_server &
 	exit 0
 ";

--- a/files/lib/freifunk/mesh-vpn/upload_key_to_server
+++ b/files/lib/freifunk/mesh-vpn/upload_key_to_server
@@ -1,12 +1,25 @@
 #!/bin/sh
 
-UPLOAD_URL=$1
+#ersteinmal warten, bis der Router komplett gestartet ist
+sleep 120
+
 KEY=`/etc/init.d/fastd show_key mesh_vpn`
 WGETC=`which wget`
 VERSION=$(cat /etc/freifunk_version)
 MAC=$(uci get freifunk.@node[0].nodeid)
+
 while [ 1 = 1 ]
 do
-        $WGETC "$UPLOAD_URL/upload_key?nodeid=${MAC}&_method=post&key=${KEY}&fw_version=${VERSION}" -O -  > /dev/null && break
-	sleep 30
+	c=1
+        #Und allen Supernodes den Key hochladen
+        while [ $c -le 8 ]
+        do
+        	UPLOAD_URL="http://fastd"$c".kbu.freifunk.net/fastd-upload"
+                $WGETC   "$UPLOAD_URL/upload_key?nodeid=${MAC}&_method=post&key=${KEY}&fw_version=${VERSION}" -O -
+                sleep 30
+                let c=$c+1
+        done
+        #Zwischen jeder neuen Runde erstmal 2 Minuten warten (wg. Traffic)
+        sleep 120
 done
+


### PR DESCRIPTION
Hallo,

ich habe mal den Script für das hochladen der Fastdkeys geändert. Jetzt läuft immer nur 1 uploadthread gleichzeitig. Danach ist 30 Sekunden Pause und dann kommt der nächste fastd-Server. Nachdem die 8 Server durchlaufen wurden wird 2 Minuten gewartet und die Schleife läuft von neuem durch.

Der Script "upload_key" unterhalb von /files/lib/freifunk/mesh-vpn wird nicht mehr benötigt.

Viele Grüße
Thomas
