### PR TITLE
Doubling waiting time after unsuccessful key uploads to maximal one day

### DIFF
--- a/files/lib/freifunk/mesh-vpn/upload_key_to_server
+++ b/files/lib/freifunk/mesh-vpn/upload_key_to_server
@@ -5,8 +5,10 @@ KEY=`/etc/init.d/fastd show_key mesh_vpn`
 WGETC=`which wget`
 VERSION=$(cat /etc/freifunk_version)
 MAC=$(uci get freifunk.@node[0].nodeid)
+DELAY=30
 while [ 1 = 1 ]
 do
-        $WGETC "$UPLOAD_URL/upload_key?nodeid=${MAC}&_method=post&key=${KEY}&fw_version=${VERSION}" -O -  > /dev/null && break
-	sleep 30
+	$WGETC "$UPLOAD_URL/upload_key?nodeid=${MAC}&_method=post&key=${KEY}&fw_version=${VERSION}" -O -  > /dev/null && break
+	sleep $DELAY
+	[ $DELAY -gt 42300 ] && DELAY=84600 || DELAY=$((DELAY * 2))
 done


### PR DESCRIPTION
Ich dachte mir, dass es nicht sinvoll ist den Schlüssel alle 30 Sek hochzuladen, wenn ein Versuch scheitert. In meinem Patch wird die Wartezeit nach einem gescheitertem Upload verdoppelt, bis zu maximal einem Tag. So bleibt das Log auch sauberer.
